### PR TITLE
Add LICENSE file and modify README.md with a license badge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Petr Sedlacek 
+
+is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miunie
 
-[![Build status](https://ci.appveyor.com/api/projects/status/cpaukw10ih35jl69?svg=true)](https://ci.appveyor.com/project/discord-bot-tutorial/miunie)
+[![Build status](https://ci.appveyor.com/api/projects/status/cpaukw10ih35jl69?svg=true)](https://ci.appveyor.com/project/discord-bot-tutorial/miunie) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/discord-bot-tutorial/Miunie/blob/master/LICENSE)
 
 Miunie is a community developed Disord bot.
 


### PR DESCRIPTION
#### Related issue
#12 

Added a MIT license, and a link to the LICENSE file in the README.md, with a cool badge