### PR TITLE
Define ProfileCommand & EntityConvertor

### DIFF
--- a/src/Miunie.Discord/CommandModules/ProfileCommand.cs
+++ b/src/Miunie.Discord/CommandModules/ProfileCommand.cs
@@ -18,7 +18,7 @@ namespace Miunie.Discord.CommandModules
         [Command("profile")]
         public async Task ShowProfile(CommandContext context, DiscordMember memeber)
         {
-            //TODO: (Charly) uncomment once EntityConvertor and ProfileService are implemented
+            //TODO: (Charly) uncomment once EntityConvertor and ProfileService are implemented, along with MiunieEntities
             //var miunieUser = _entityConvertor.DiscordMemberToMiunieUser(member);
             //var miunieChannel = _entityConvertor.DiscordChannelToMiunieUser(context.Channel);
             //_profileService.ShowProfile(miunieUser, miunieChannel);

--- a/src/Miunie.Discord/CommandModules/ProfileCommand.cs
+++ b/src/Miunie.Discord/CommandModules/ProfileCommand.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+using Miunie.Discord.Convertors;
+
+namespace Miunie.Discord.CommandModules
+{
+    public class ProfileCommand
+    {
+        EntityConvertor _entityConvertor;
+
+        public ProfileCommand(EntityConvertor entityConvertor)
+        {
+            _entityConvertor = entityConvertor;
+        }
+
+        [Command("profile")]
+        public async Task ShowProfile(CommandContext context, DiscordMember memeber)
+        {
+            //TODO: (Charly) uncomment once EntityConvertor and ProfileService are implemented
+            //var miunieUser = _entityConvertor.DiscordMemberToMiunieUser(member);
+            //var miunieChannel = _entityConvertor.DiscordChannelToMiunieUser(context.Channel);
+            //_profileService.ShowProfile(miunieUser, miunieChannel);
+        }
+    }
+}

--- a/src/Miunie.Discord/Convertors/EntityConvertor.cs
+++ b/src/Miunie.Discord/Convertors/EntityConvertor.cs
@@ -1,0 +1,11 @@
+namespace Miunie.Discord.Convertors
+{
+    /// <summary>
+    /// This class purpose is to convert DSharpPlus entities
+    /// to Miunie entities.
+    /// </summary>
+    public class EntityConvertor
+    {
+        
+    }
+}

--- a/src/Miunie.Discord/Convertors/EntityConvertor.cs
+++ b/src/Miunie.Discord/Convertors/EntityConvertor.cs
@@ -6,6 +6,26 @@ namespace Miunie.Discord.Convertors
     /// </summary>
     public class EntityConvertor
     {
-        
+        //TODO: (Charly) Uncomment and implement the following methods,
+        // once we have the Miunie entities implemented
+        // NOTE: You're free to change the methods names
+
+        /*
+        public MiunieUser DiscordMemberToMiunieUser(DiscordMember discordMember)
+        {
+            var miunieUser = new MiunieUser();
+            //fill the miunieUser properties with the discordMember properties
+            return miunieUser;
+        }
+         */
+         
+         /*
+        public MiunieChannel DiscordChannelToMiunieUser(DiscordChannel discordChannel)
+        {
+            var miunieChannel = new MiunieChannel();
+            //fill the miunieChannel properties with the discordChannel properties
+            return miunieChannel;
+        }
+         */
     }
 }


### PR DESCRIPTION
### Related issue
#20 

### Changes
- Added the `EntityConvertor` and `ProfileCommand` classes.
- Setted up DSharpPlus Dependency Injecction.
- Commented implementation in `EntityConvertor` and `ProfileCommand`.
### To do
`EntityConvertor` and `ProfileCommand` depends of other classes to be functional, that aren't implemented yet.
This will be solved with #19 and #21.
Will open an issue about this 👍 
### Expected Feedback
#### About registering commands
To register the commands to the command service, we have a few options,
We could pass the Entry assembly to the [`RegisterCommands(Assembly)`](https://dsharpplus.emzi0767.com/api/DSharpPlus.CommandsNext.CommandsNextModule.html#DSharpPlus_CommandsNext_CommandsNextModule_RegisterCommands_Assembly_) method to register all commands that are in the assembly, or, what I did, register each command module manually, using the [`RegisterCommands<Module>()`](https://dsharpplus.emzi0767.com/api/DSharpPlus.CommandsNext.CommandsNextModule.html#DSharpPlus_CommandsNext_CommandsNextModule_RegisterCommands__1) class:
```cs
_commandsNextModule.RegisterCommands<CommandModules.ProfileCommand>();
```
Personally I prefe this way, forces us to register the module every time we create it, what do you think about it?

#### About the Entity Convertor
I assumed it would be a service we can use to get a `Miunie Entity` from a given `DSharpPlus Entity`, but reading the [DSharpPlus documentation](https://dsharpplus.emzi0767.com/api/DSharpPlus.CommandsNext.Converters.html), found this, wich could let us convert `Discord Entities` to `Miunie Entities`, allowing us to use `Miunie Entities` as command parameters, thoughts?
___
As always, any kind of constructive feedback is welcome :)