### PR TITLE
Implement ListDirectoryService

### DIFF
--- a/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
+++ b/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xunit;
 using Miunie.Core;
 using Miunie.Core.Services;
@@ -14,7 +15,8 @@ namespace Miunie.Core.XUnit.Tests
         {
             var serversMock = new DiscordServersMock(
                 123456789,
-                "TestServer"
+                "TestServer",
+                new []{ "ChannelA", "ChannelB", "ChannelC" }
             );
 
             _ls = new ListDirectoryService(serversMock);
@@ -25,6 +27,22 @@ namespace Miunie.Core.XUnit.Tests
         {
             const string expected = "Data\nTestServer";
             var inputUser = new MiunieUser();
+            var inputChannel = new MiunieChannel
+            {
+                GuildId = 123456789
+            };
+            var actual = _ls.Of(inputUser, inputChannel);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void InServerShouldOutputChannels()
+        {
+            const string expected = "ChannelA\nChannelB\nChannelC";
+            var inputUser = new MiunieUser
+            {
+                NavCursor = new List<ulong> { 123456789 }
+            };
             var inputChannel = new MiunieChannel
             {
                 GuildId = 123456789

--- a/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
+++ b/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
@@ -10,28 +10,31 @@ namespace Miunie.Core.XUnit.Tests
     public class ListDirectoryTest
     {
         private readonly ListDirectoryService _ls;
+        private readonly MiunieChannel _testChannel;
+        private const ulong TestServerId = 123456789;
+        private const string TestServerName = "TestServer";
 
         public ListDirectoryTest()
         {
             var serversMock = new DiscordServersMock(
-                123456789,
-                "TestServer",
+                TestServerId,
+                TestServerName,
                 new []{ "ChannelA", "ChannelB", "ChannelC" }
             );
 
             _ls = new ListDirectoryService(serversMock);
+            _testChannel = new MiunieChannel
+            {
+                GuildId = TestServerId
+            };
         }
 
         [Fact]
         public void EmptyShouldOutputRoot()
         {
-            const string expected = "Data\nTestServer";
+            string expected = $"Data\n{TestServerName}";
             var inputUser = new MiunieUser();
-            var inputChannel = new MiunieChannel
-            {
-                GuildId = 123456789
-            };
-            var actual = _ls.Of(inputUser, inputChannel);
+            var actual = _ls.Of(inputUser, _testChannel);
             Assert.Equal(expected, actual);
         }
 
@@ -41,13 +44,9 @@ namespace Miunie.Core.XUnit.Tests
             const string expected = "ChannelA\nChannelB\nChannelC";
             var inputUser = new MiunieUser
             {
-                NavCursor = new List<ulong> { 123456789 }
+                NavCursor = new List<ulong> { TestServerId }
             };
-            var inputChannel = new MiunieChannel
-            {
-                GuildId = 123456789
-            };
-            var actual = _ls.Of(inputUser, inputChannel);
+            var actual = _ls.Of(inputUser, _testChannel);
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
+++ b/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
@@ -10,7 +10,6 @@ namespace Miunie.Core.XUnit.Tests
     public class ListDirectoryTest
     {
         private readonly ListDirectoryService _ls;
-        private readonly MiunieChannel _testChannel;
         private const ulong TestServerId = 123456789;
         private const string TestServerName = "TestServer";
 
@@ -23,18 +22,17 @@ namespace Miunie.Core.XUnit.Tests
             );
 
             _ls = new ListDirectoryService(serversMock);
-            _testChannel = new MiunieChannel
-            {
-                GuildId = TestServerId
-            };
         }
 
         [Fact]
         public void EmptyShouldOutputRoot()
         {
             string expected = $"Data\n{TestServerName}";
-            var inputUser = new MiunieUser();
-            var actual = _ls.Of(inputUser, _testChannel);
+            var inputUser = new MiunieUser
+            {
+                GuildId = TestServerId
+            };
+            var actual = _ls.Of(inputUser);
             Assert.Equal(expected, actual);
         }
 
@@ -44,9 +42,10 @@ namespace Miunie.Core.XUnit.Tests
             const string expected = "ChannelA\nChannelB\nChannelC";
             var inputUser = new MiunieUser
             {
+                GuildId = TestServerId,
                 NavCursor = new List<ulong> { TestServerId }
             };
-            var actual = _ls.Of(inputUser, _testChannel);
+            var actual = _ls.Of(inputUser);
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
+++ b/src/Miunie.Core.XUnit.Tests/ListDirectoryTest.cs
@@ -1,0 +1,37 @@
+using System;
+using Xunit;
+using Miunie.Core;
+using Miunie.Core.Services;
+using Miunie.Core.Discord;
+
+namespace Miunie.Core.XUnit.Tests
+{
+    public class ListDirectoryTest
+    {
+        private readonly ListDirectoryService _ls;
+
+        public ListDirectoryTest()
+        {
+            var serversMock = new DiscordServersMock(
+                123456789,
+                "TestServer"
+            );
+
+            _ls = new ListDirectoryService(serversMock);
+        }
+
+        [Fact]
+        public void EmptyShouldOutputRoot()
+        {
+            const string expected = "Data\nTestServer";
+            var inputUser = new MiunieUser();
+            var inputChannel = new MiunieChannel
+            {
+                GuildId = 123456789
+            };
+            var actual = _ls.Of(inputUser, inputChannel);
+            Assert.Equal(expected, actual);
+        }
+    }
+}
+

--- a/src/Miunie.Core.XUnit.Tests/Mocks/DiscordServersMock.cs
+++ b/src/Miunie.Core.XUnit.Tests/Mocks/DiscordServersMock.cs
@@ -1,0 +1,24 @@
+using Miunie.Core.Discord;
+using Xunit;
+
+namespace Miunie.Core.XUnit.Tests
+{
+    public class DiscordServersMock : IDiscordServers
+    {
+        private readonly ulong _acceptedId;
+        private readonly string _returnedName;
+
+        public DiscordServersMock(ulong acceptedId, string returnedName)
+        {
+            _acceptedId = acceptedId;
+            _returnedName = returnedName;
+        }
+
+        public string GetServerNameById(ulong id)
+        {
+            Assert.Equal(_acceptedId, id);
+            return _returnedName;
+        }
+    }
+}
+

--- a/src/Miunie.Core.XUnit.Tests/Mocks/DiscordServersMock.cs
+++ b/src/Miunie.Core.XUnit.Tests/Mocks/DiscordServersMock.cs
@@ -7,17 +7,28 @@ namespace Miunie.Core.XUnit.Tests
     {
         private readonly ulong _acceptedId;
         private readonly string _returnedName;
+        private readonly string[] _returnedChannelNames;
 
-        public DiscordServersMock(ulong acceptedId, string returnedName)
+        public DiscordServersMock(
+                ulong acceptedId, 
+                string returnedName, 
+                string[] returnedChannelNames)
         {
             _acceptedId = acceptedId;
             _returnedName = returnedName;
+            _returnedChannelNames = returnedChannelNames;
         }
 
         public string GetServerNameById(ulong id)
         {
             Assert.Equal(_acceptedId, id);
             return _returnedName;
+        }
+
+        public string[] GetChannelNamesFromServer(ulong id)
+        {
+            Assert.Equal(_acceptedId, id);
+            return _returnedChannelNames;
         }
     }
 }

--- a/src/Miunie.Core/Discord/IDiscordServers.cs
+++ b/src/Miunie.Core/Discord/IDiscordServers.cs
@@ -1,0 +1,8 @@
+namespace Miunie.Core.Discord
+{
+    public interface IDiscordServers
+    {
+        string GetServerNameById(ulong id);
+    }
+}
+

--- a/src/Miunie.Core/Discord/IDiscordServers.cs
+++ b/src/Miunie.Core/Discord/IDiscordServers.cs
@@ -3,6 +3,7 @@ namespace Miunie.Core.Discord
     public interface IDiscordServers
     {
         string GetServerNameById(ulong id);
+        string[] GetChannelNamesFromServer(ulong id);
     }
 }
 

--- a/src/Miunie.Core/Entities/MiunieUser.cs
+++ b/src/Miunie.Core/Entities/MiunieUser.cs
@@ -1,9 +1,17 @@
+using System.Collections.Generic;
+
 namespace Miunie.Core
 {
     public class MiunieUser
     {
         public ulong Id { get; set; }
         public long Reputation { get; set; }
+        public List<ulong> NavCursor { get; set; }
+
+        public MiunieUser()
+        {
+            NavCursor = new List<ulong>();
+        }
     }
 }
 

--- a/src/Miunie.Core/Services/ListDirectoryService.cs
+++ b/src/Miunie.Core/Services/ListDirectoryService.cs
@@ -1,0 +1,33 @@
+using Miunie.Core;
+using Miunie.Core.Discord;
+using System.Linq;
+
+namespace Miunie.Core.Services
+{
+    public class ListDirectoryService
+    {
+        private readonly IDiscordServers _discordServers;
+
+        public ListDirectoryService(IDiscordServers discordServers)
+        {
+            _discordServers = discordServers;
+        }
+
+        public string Of(MiunieUser user, MiunieChannel channel)
+        {
+            if(!user.NavCursor.Any())
+            {
+                return GetRootOf(channel);
+            }
+
+            return string.Empty;
+        }
+
+        public string GetRootOf(MiunieChannel channel)
+        {
+            var serverName = _discordServers.GetServerNameById(channel.GuildId);
+            return $"Data\n{serverName}";
+        }
+    }
+}
+

--- a/src/Miunie.Core/Services/ListDirectoryService.cs
+++ b/src/Miunie.Core/Services/ListDirectoryService.cs
@@ -19,6 +19,10 @@ namespace Miunie.Core.Services
             {
                 return GetRootOf(channel);
             }
+            if(user.NavCursor.Count == 1)
+            {
+                return GetChannelsOf(channel);
+            }
 
             return string.Empty;
         }
@@ -27,6 +31,14 @@ namespace Miunie.Core.Services
         {
             var serverName = _discordServers.GetServerNameById(channel.GuildId);
             return $"Data\n{serverName}";
+        }
+
+        public string GetChannelsOf(MiunieChannel channel)
+        {
+            var channelNames = _discordServers
+                .GetChannelNamesFromServer(channel.GuildId);
+
+            return string.Join("\n", channelNames);
         }
     }
 }

--- a/src/Miunie.Core/Services/ListDirectoryService.cs
+++ b/src/Miunie.Core/Services/ListDirectoryService.cs
@@ -14,30 +14,30 @@ namespace Miunie.Core.Services
             _discordServers = discordServers;
         }
 
-        public string Of(MiunieUser user, MiunieChannel channel)
+        public string Of(MiunieUser user)
         {
             if(!user.NavCursor.Any())
             {
-                return GetRootOf(channel);
+                return GetRootOf(user);
             }
             if(user.NavCursor.Count == 1)
             {
-                return GetChannelsOf(channel);
+                return GetChannelsOf(user);
             }
 
             return string.Empty;
         }
 
-        public string GetRootOf(MiunieChannel channel)
+        public string GetRootOf(MiunieUser user)
         {
-            var serverName = _discordServers.GetServerNameById(channel.GuildId);
+            var serverName = _discordServers.GetServerNameById(user.GuildId);
             return $"Data{Separator}{serverName}";
         }
 
-        public string GetChannelsOf(MiunieChannel channel)
+        public string GetChannelsOf(MiunieUser user)
         {
             var channelNames = _discordServers
-                .GetChannelNamesFromServer(channel.GuildId);
+                .GetChannelNamesFromServer(user.GuildId);
 
             return string.Join(Separator, channelNames);
         }

--- a/src/Miunie.Core/Services/ListDirectoryService.cs
+++ b/src/Miunie.Core/Services/ListDirectoryService.cs
@@ -7,6 +7,7 @@ namespace Miunie.Core.Services
     public class ListDirectoryService
     {
         private readonly IDiscordServers _discordServers;
+        private const string Separator = "\n";
 
         public ListDirectoryService(IDiscordServers discordServers)
         {
@@ -30,7 +31,7 @@ namespace Miunie.Core.Services
         public string GetRootOf(MiunieChannel channel)
         {
             var serverName = _discordServers.GetServerNameById(channel.GuildId);
-            return $"Data\n{serverName}";
+            return $"Data{Separator}{serverName}";
         }
 
         public string GetChannelsOf(MiunieChannel channel)
@@ -38,7 +39,7 @@ namespace Miunie.Core.Services
             var channelNames = _discordServers
                 .GetChannelNamesFromServer(channel.GuildId);
 
-            return string.Join("\n", channelNames);
+            return string.Join(Separator, channelNames);
         }
     }
 }


### PR DESCRIPTION
## Changes
Creates a ListDirectoryService to allow for the `ls` command.
The service is not fully implemented. However, it serves as a proof of concept about storing information about the directory structure.

One thing I'm not a fan of is the need for a MiunieChannel to be passed into the ls command.
We have to do that, since there is nothing that could tell us what server the user is talking about.

**Solution:** We need to rework the `MiunieUser` to be per-guild rather than global.

## Expected Feedback
The main thing about this PR is the structure. Therefore, we should focus on how `ls` is implemented and perhaps find a better implementation.