### PR TITLE
Implement DateTime abstraction

### DIFF
--- a/src/Miunie.ConsoleApp/InversionOfControl.cs
+++ b/src/Miunie.ConsoleApp/InversionOfControl.cs
@@ -2,6 +2,7 @@ using Miunie.Configuration;
 using Miunie.Core;
 using Miunie.Core.Storage;
 using Miunie.Core.Language;
+using Miunie.Core.Infrastructure;
 using Miunie.Storage;
 using Miunie.Discord;
 using Miunie.Discord.Configuration;
@@ -44,6 +45,7 @@ namespace Miunie.ConsoleApp
                 .AddSingleton<Random>()
                 .AddSingleton<IMiunieUserProvider, MiunieUserProvider>()
                 .AddTransient<IUserReputationProvider, UserReputationProvider>()
+                .AddTransient<IDateTime, SystemDateTime>()
                 .BuildServiceProvider();
     }
 }

--- a/src/Miunie.Core.XUnit.Tests/Providers/UserReputationProviderTests.cs
+++ b/src/Miunie.Core.XUnit.Tests/Providers/UserReputationProviderTests.cs
@@ -1,4 +1,6 @@
+using System;
 using Miunie.Core.Providers;
+using Miunie.Core.Infrastructure;
 using Xunit;
 using Moq;
 
@@ -7,50 +9,56 @@ namespace Miunie.Core.XUnit.Tests.Providers
     public class UserReputationProviderTests
     {
         private readonly IUserReputationProvider _reputationProvider;
+        private readonly Mock<IDateTime> _dateTimeMock;
         private readonly DummyMiunieUsers _data = new DummyMiunieUsers();
 
         public UserReputationProviderTests()
         {
-            _reputationProvider = new UserReputationProvider(new Mock<IMiunieUserProvider>().Object);
+            _dateTimeMock = new Mock<IDateTime>();
+            _reputationProvider = new UserReputationProvider(new Mock<IMiunieUserProvider>().Object, _dateTimeMock.Object);
         }
 
         [Fact]
         public void ShouldAddReputation()
         {
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             var expectedReputation = _data.Senne.Reputation.Value + 1;
-            
+
             _reputationProvider.AddReputation(_data.Peter, _data.Senne);
-            
+
             Assert.Equal(expectedReputation, _data.Senne.Reputation.Value);
         }
 
         [Fact]
         public void ShouldGetTimeoutAfterAddingReputation()
         {
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             var expectedReputation = _data.Senne.Reputation.Value + 1;
-            
+
             Assert.False(_reputationProvider.AddReputationHasTimeout(_data.Peter, _data.Senne));
-            
+
             _reputationProvider.AddReputation(_data.Peter, _data.Senne);
-            
+
             Assert.True(_reputationProvider.AddReputationHasTimeout(_data.Peter, _data.Senne));
             Assert.False(_reputationProvider.AddReputationHasTimeout(_data.Senne, _data.Peter));
             Assert.Equal(expectedReputation, _data.Senne.Reputation.Value);
         }
-        
+
         [Fact]
         public void ShouldRemoveReputation()
         {
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             var expectedReputation = _data.Senne.Reputation.Value - 1;
-            
+
             _reputationProvider.RemoveReputation(_data.Peter, _data.Senne);
-            
+
             Assert.Equal(expectedReputation, _data.Senne.Reputation.Value);
         }
 
         [Fact]
         public void ShouldGetTimeoutAfterRemovingReputation()
         {
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             var expectedReputation = _data.Senne.Reputation.Value - 1;
 
             Assert.False(_reputationProvider.RemoveReputationHasTimeout(_data.Peter, _data.Senne));
@@ -61,5 +69,40 @@ namespace Miunie.Core.XUnit.Tests.Providers
             Assert.False(_reputationProvider.RemoveReputationHasTimeout(_data.Senne, _data.Peter));
             Assert.Equal(expectedReputation, _data.Senne.Reputation.Value);
         }
+
+        [Fact]
+        public void ShouldRemoveTimeoutForAddingEventually()
+        {
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
+            var expectedReputation = _data.Senne.Reputation.Value + 1;
+
+            Assert.False(_reputationProvider.AddReputationHasTimeout(_data.Peter, _data.Senne));
+
+            _reputationProvider.AddReputation(_data.Peter, _data.Senne);
+
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now.AddHours(1));
+
+            Assert.False(_reputationProvider.AddReputationHasTimeout(_data.Peter, _data.Senne));
+            Assert.False(_reputationProvider.AddReputationHasTimeout(_data.Senne, _data.Peter));
+            Assert.Equal(expectedReputation, _data.Senne.Reputation.Value);
+        }
+
+        [Fact]
+        public void ShouldRemoveTimeoutForRemovingEventually()
+        {
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
+            var expectedReputation = _data.Senne.Reputation.Value - 1;
+
+            Assert.False(_reputationProvider.RemoveReputationHasTimeout(_data.Peter, _data.Senne));
+
+            _reputationProvider.RemoveReputation(_data.Peter, _data.Senne);
+
+            _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now.AddHours(1));
+
+            Assert.False(_reputationProvider.RemoveReputationHasTimeout(_data.Peter, _data.Senne));
+            Assert.False(_reputationProvider.RemoveReputationHasTimeout(_data.Senne, _data.Peter));
+            Assert.Equal(expectedReputation, _data.Senne.Reputation.Value);
+        }
     }
 }
+

--- a/src/Miunie.Core.XUnit.Tests/Providers/UserReputationProviderTests.cs
+++ b/src/Miunie.Core.XUnit.Tests/Providers/UserReputationProviderTests.cs
@@ -76,9 +76,8 @@ namespace Miunie.Core.XUnit.Tests.Providers
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             var expectedReputation = _data.Senne.Reputation.Value + 1;
 
-            Assert.False(_reputationProvider.AddReputationHasTimeout(_data.Peter, _data.Senne));
-
-            _reputationProvider.AddReputation(_data.Peter, _data.Senne);
+            _data.Senne.Reputation.Value = expectedReputation;
+            Assert.True(_data.Senne.Reputation.PlusRepLog.TryAdd(_data.Peter.Id, DateTime.Now));
 
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now.AddHours(1));
 
@@ -93,9 +92,8 @@ namespace Miunie.Core.XUnit.Tests.Providers
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             var expectedReputation = _data.Senne.Reputation.Value - 1;
 
-            Assert.False(_reputationProvider.RemoveReputationHasTimeout(_data.Peter, _data.Senne));
-
-            _reputationProvider.RemoveReputation(_data.Peter, _data.Senne);
+            _data.Senne.Reputation.Value = expectedReputation;
+            Assert.True(_data.Senne.Reputation.MinusRepLog.TryAdd(_data.Peter.Id, DateTime.Now));
 
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now.AddHours(1));
 

--- a/src/Miunie.Core/Infrastructure/IDateTime.cs
+++ b/src/Miunie.Core/Infrastructure/IDateTime.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Miunie.Core.Infrastructure
+{
+    public interface IDateTime
+    {
+        DateTime Now { get; }
+    }
+}
+

--- a/src/Miunie.Core/Infrastructure/SystemDateTime.cs
+++ b/src/Miunie.Core/Infrastructure/SystemDateTime.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Miunie.Core.Infrastructure
+{
+    public class SystemDateTime : IDateTime
+    {
+        public DateTime Now => DateTime.Now;
+    }
+}
+


### PR DESCRIPTION
## Related Issue

Fixes #77 

## Changes
Introduces a new `Miunie.Core.Infrastructure` namespaces with `IDateTime > SystemDateTime` in it.
Because of this abstraction, we can (and do) test that the reputation timeout doesn't apply after 30 minutes without having to actually wait that long.

EDIT:
I also detached the tests... The "Reputation timeout should reset" were dependent on the fact that giving reputation will result in a timeout. If the test that check if "adding reputation works" failed, the "reputation timeout should reset" would fail too.

With my edit, this won't happen. "Reputation timeout should reset" will only fail when the thing it's actually testing fails.

## Expected Feedback
Sanity checks, maybe I did something super stupid. I did this one without Intellisense since I was on battery power. (it does build, tests pass, and I tested Miunie locally and she works)
