### PR TITLE
Fix windows 1803 compatibility issues

### DIFF
--- a/src/Miunie.WindowsApp/App.xaml
+++ b/src/Miunie.WindowsApp/App.xaml
@@ -5,6 +5,11 @@
     xmlns:local="using:Miunie.WindowsApp"
     xmlns:vm="using:Miunie.WindowsApp.ViewModels">
     <Application.Resources>
-        <vm:ViewModelLocator xmlns:vm="using:Miunie.WindowsApp.ViewModels" x:Key="Locator"/>
+        <ResourceDictionary>
+            <vm:ViewModelLocator xmlns:vm="using:Miunie.WindowsApp.ViewModels" x:Key="Locator"/>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Miunie.WindowsApp/Miunie.WindowsApp.csproj
+++ b/src/Miunie.WindowsApp/Miunie.WindowsApp.csproj
@@ -212,6 +212,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.8</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml">
+      <Version>2.1.190405004</Version>
+    </PackageReference>
     <PackageReference Include="MvvmLight">
       <Version>5.4.1.1</Version>
     </PackageReference>

--- a/src/Miunie.WindowsApp/Views/StartPage.xaml
+++ b/src/Miunie.WindowsApp/Views/StartPage.xaml
@@ -5,22 +5,37 @@
     xmlns:local="using:Miunie.WindowsApp.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource SystemControlAcrylicWindowMediumHighBrush}"
     DataContext="{Binding StartPageInstance, Source={StaticResource Locator}}"
     GotFocus="StartPage_OnGotFocus">
 
     <Grid>
-        <NavigationView Name="MainNavigationView"
+        <muxc:NavigationView Name="MainNavigationView"
                         Loaded="MainNavigationView_OnLoaded"
                         ItemInvoked="MainNavigationView_OnItemInvoked">
-            <NavigationView.MenuItems>
-                <NavigationViewItem Tag="home" Icon="Emoji" Content="Bot status" />
-                <NavigationViewItemSeparator/>
-            </NavigationView.MenuItems>
+            <muxc:NavigationView.MenuItems>
+                <muxc:NavigationViewItem Tag="home" Icon="Emoji" Content="Bot status" />
+                <muxc:NavigationViewItemSeparator/>
+            </muxc:NavigationView.MenuItems>
             <Grid>
                 <Frame Name="MainFrame" />
             </Grid>
-        </NavigationView>
+        </muxc:NavigationView>
     </Grid>
+
+    <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup>
+            <VisualState>
+                <VisualState.StateTriggers>
+                    <AdaptiveTrigger
+                        MinWindowWidth="{x:Bind MainNavigationView.CompactModeThresholdWidth}"/>
+                </VisualState.StateTriggers>
+                <VisualState.Setters>
+                    <Setter Target="ContentFrame.Padding" Value="24,0,24,24"/>
+                </VisualState.Setters>
+            </VisualState>
+        </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
 </Page>

--- a/src/Miunie.WindowsApp/Views/StartPage.xaml.cs
+++ b/src/Miunie.WindowsApp/Views/StartPage.xaml.cs
@@ -15,6 +15,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 using Miunie.WindowsApp.ViewModels;
+using muxc = Microsoft.UI.Xaml.Controls;
 
 namespace Miunie.WindowsApp.Views
 {
@@ -45,7 +46,7 @@ namespace Miunie.WindowsApp.Views
             CheckForTokenInClipboard();
         }
 
-        private void MainNavigationView_OnItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+        private void MainNavigationView_OnItemInvoked(muxc.NavigationView sender, muxc.NavigationViewItemInvokedEventArgs args)
         {
             if (args.IsSettingsInvoked)
             {


### PR DESCRIPTION
## Related Issue

Fixes #126 

## Changes
- Add the compatibility NuGet package by Microsoft
- Merge the NuGet's control into our resources
- Use the compatible control namespace for NavigationView. 

## Expected Feedback
Please ensure this runs on Windows 10 1803 **and** 1809.