### PR TITLE
Add '#' in front of channel names

### DIFF
--- a/src/Miunie.Discord/Impersonation.cs
+++ b/src/Miunie.Discord/Impersonation.cs
@@ -40,7 +40,7 @@ namespace Miunie.Discord
                     result.Add(new TextChannelView
                     {
                         Id = channel.Id,
-                        Name = channel.Name,
+                        Name = $"# {channel.Name}",
                         Messages = await GetMessagesFrom(channel)
                     });
                 }


### PR DESCRIPTION
## Related Issue

Fixes #135 

## Changes
Name speaks for itself. 😄 Add '#' in front of channel names.

## Expected Feedback
Everything works and waits to be merged.