### PR TITLE
Re-Implement ConfigManager For Console App

### DIFF
--- a/src/Miunie.ConsoleApp/Configuration/ConfigManager.cs
+++ b/src/Miunie.ConsoleApp/Configuration/ConfigManager.cs
@@ -47,7 +47,7 @@ namespace Miunie.ConsoleApp.Configuration
 
         private static string RandomString(int length)
         {
-            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.";
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-";
             var random = new Random();
             return new string(Enumerable.Repeat(chars, length)
               .Select(s => s[random.Next(s.Length)]).ToArray());

--- a/src/Miunie.ConsoleApp/Configuration/ConigurationFileEditor.cs
+++ b/src/Miunie.ConsoleApp/Configuration/ConigurationFileEditor.cs
@@ -2,22 +2,22 @@
 
 namespace Miunie.ConsoleApp.Configuration
 {
-    class ConfigurationFileEditor
+    public class ConfigurationFileEditor
     {
         private readonly System.Configuration.Configuration _file;
 
-        internal ConfigurationFileEditor()
+        public ConfigurationFileEditor()
         {
             _file = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
         }
 
-        internal void Save()
+        public void Save()
         {
             _file.Save(ConfigurationSaveMode.Modified);
             ConfigurationManager.RefreshSection(_file.AppSettings.SectionInformation.Name);
         }
 
-        internal void WriteSetting(string key, string value)
+        public void WriteSetting(string key, string value)
         {
             if (SettingExists(key))
             {

--- a/src/Miunie.ConsoleApp/InversionOfControl.cs
+++ b/src/Miunie.ConsoleApp/InversionOfControl.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Miunie.ConsoleApp.Configuration;
 using Miunie.Core.Infrastructure;
 using Miunie.Core.Logging;
 using Miunie.InversionOfControl;
@@ -27,6 +28,8 @@ namespace Miunie.ConsoleApp
                 .AddSingleton<ILogWriter, ConsoleBottomLogger>()
                 .AddTransient<IDateTime, SystemDateTime>()
                 .AddSingleton<IFileSystem, SystemFileSystem>()
+                .AddSingleton<ConfigManager>()
+                .AddSingleton<ConfigurationFileEditor>()
                 .AddMiunieTypes()
                 .BuildServiceProvider();
     }

--- a/src/Miunie.ConsoleApp/Program.cs
+++ b/src/Miunie.ConsoleApp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Miunie.ConsoleApp.Configuration;
 using Miunie.Core;
 using System;
 
@@ -7,10 +8,14 @@ namespace Miunie.ConsoleApp
     internal static class Program
     {
         private static MiunieBot _miunie;
+        private static ConfigManager _configManager;
+        private static ConfigurationFileEditor _editor;
 
-        private static void Main()
+        private static void Main(string[] args)
         {
             _miunie = ActivatorUtilities.CreateInstance<MiunieBot>(InversionOfControl.Provider);
+            _configManager = InversionOfControl.Provider.GetRequiredService<ConfigManager>();
+            _editor = InversionOfControl.Provider.GetRequiredService<ConfigurationFileEditor>();
             _miunie.MiunieDiscord.ConnectionChanged += MiunieOnConnectionStateChanged;
             HandleInput();
         }
@@ -50,6 +55,8 @@ namespace Miunie.ConsoleApp
                             Console.WriteLine(ConsoleStrings.YES_NO_PROMPT);
                         } while (Console.ReadKey().Key != ConsoleKey.Y);
 
+                        _editor.WriteSetting("DiscordToken", token);
+                        _editor.Save();
                         _miunie.BotConfiguration.DiscordToken = token;
                         break;
                     }
@@ -61,6 +68,7 @@ namespace Miunie.ConsoleApp
                         }
                         else if(_miunie.MiunieDiscord.ConnectionState == ConnectionState.DISCONNECTED)
                         {
+                            _miunie.BotConfiguration.DiscordToken = _configManager.GetValueFor("DiscordToken");
                             _ = _miunie.StartAsync();
                         }
                         break;


### PR DESCRIPTION
Fixes #144 

## Changes

* Re-Implement `ConfigManager` and `ConfigerationFileEditor` for the Console App front end.
* This PR should allow users to use `Option 1` on the Console App to set their desired token, this will create a new config file and save the users desired token into said App.config.
* This PR also adds persistense for the users token, once it is set, they're able to use `Option 2` to simply start up the bot without having to provide a token all the time.
* **NOTE** They're also able to use option 2 to start the bot, if the bot see's there is no token available, it will request the user enter one (as it was originally).

## Expected Feedback
Just let me know if it works for you or if you have any bugs please.