### PR TITLE
MiunieUser DB Refactor

### DIFF
--- a/src/Miunie.Core.XUnit.Tests/Data/DummyMiunieUsers.cs
+++ b/src/Miunie.Core.XUnit.Tests/Data/DummyMiunieUsers.cs
@@ -6,7 +6,7 @@ namespace Miunie.Core.XUnit.Tests.Data
 
         public readonly MiunieUser Senne = new MiunieUser
         {
-            Id = 69420911,
+            UserId = 69420911,
             GuildId = DummyGuildId,
             Name = "Senne",
             Reputation = new Reputation
@@ -17,7 +17,7 @@ namespace Miunie.Core.XUnit.Tests.Data
 
         public readonly MiunieUser Peter = new MiunieUser
         {
-            Id = 182941761801420802,
+            UserId = 182941761801420802,
             GuildId = DummyGuildId,
             Name = "Peter",
             Reputation = new Reputation
@@ -28,7 +28,7 @@ namespace Miunie.Core.XUnit.Tests.Data
 
         public readonly MiunieUser Drax = new MiunieUser
         {
-            Id = 123456789,
+            UserId = 123456789,
             GuildId = DummyGuildId,
             Name = "Drax",
             Reputation = new Reputation

--- a/src/Miunie.Core.XUnit.Tests/Providers/MiunieUserProviderTests.cs
+++ b/src/Miunie.Core.XUnit.Tests/Providers/MiunieUserProviderTests.cs
@@ -20,7 +20,7 @@ namespace Miunie.Core.XUnit.Tests.Providers
             _storageMock = new Mock<IPersistentStorage>();
             _userProvider = new MiunieUserProvider(_storageMock.Object);
             _users = new DummyMiunieUsers();
-            _hasDraxIdAndGuildId = u => u.Id == _users.Drax.Id && u.GuildId == _users.Drax.GuildId;
+            _hasDraxIdAndGuildId = u => u.UserId == _users.Drax.UserId && u.GuildId == _users.Drax.GuildId;
         }
 
         [Fact]
@@ -31,11 +31,11 @@ namespace Miunie.Core.XUnit.Tests.Providers
                 .Returns(expected);
             _storageMock.Setup(s => s.Store(It.IsAny<MiunieUser>()));
 
-            var actual = _userProvider.GetById(expected.Id, expected.GuildId);
+            var actual = _userProvider.GetById(expected.UserId, expected.GuildId);
 
             _storageMock.Verify(s => s.RestoreSingle(It.IsAny<Expression<Func<MiunieUser, bool>>>()), Times.Once);
             _storageMock.Verify(s => s.Store(It.Is<MiunieUser>(_hasDraxIdAndGuildId)), Times.Never);
-            Assert.True(expected.Id == actual.Id && expected.GuildId == actual.GuildId);
+            Assert.True(expected.UserId == actual.UserId && expected.GuildId == actual.GuildId);
         }
 
         [Theory]
@@ -51,8 +51,8 @@ namespace Miunie.Core.XUnit.Tests.Providers
             var newUser = _userProvider.GetById(userId, guildID);
 
             _storageMock.Verify(s => s.RestoreSingle(It.IsAny<Expression<Func<MiunieUser, bool>>>()), Times.Once);
-            _storageMock.Verify(s => s.Store(It.Is<MiunieUser>(u => u.Id == userId && u.GuildId == guildID)), Times.Once);
-            Assert.True(newUser.Id == userId && newUser.GuildId == guildID);
+            _storageMock.Verify(s => s.Store(It.Is<MiunieUser>(u => u.UserId == userId && u.GuildId == guildID)), Times.Once);
+            Assert.True(newUser.UserId == userId && newUser.GuildId == guildID);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Miunie.Core.XUnit.Tests.Providers
             var user = new MiunieUser
             {
                 GuildId = 0,
-                Id = 0,
+                UserId = 0,
                 Reputation = new Reputation()
             };
             _storageMock.Setup(s => s.Store(It.IsAny<MiunieUser>()));

--- a/src/Miunie.Core.XUnit.Tests/Providers/UserReputationProviderTests.cs
+++ b/src/Miunie.Core.XUnit.Tests/Providers/UserReputationProviderTests.cs
@@ -80,7 +80,7 @@ namespace Miunie.Core.XUnit.Tests.Providers
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             _users.Senne.Reputation.Value++;
 
-            var hasAddedRep = _users.Senne.Reputation.PlusRepLog.TryAdd(_users.Peter.Id, DateTime.Now);
+            var hasAddedRep = _users.Senne.Reputation.PlusRepLog.TryAdd(_users.Peter.UserId, DateTime.Now);
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now.AddSeconds(_repProvider.TimeoutInSeconds + 1));
             var peterHasTimeout = _repProvider.CanAddReputation(_users.Peter, _users.Senne);
             var senneHasTimeout = _repProvider.CanAddReputation(_users.Senne, _users.Peter);
@@ -96,7 +96,7 @@ namespace Miunie.Core.XUnit.Tests.Providers
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now);
             _users.Senne.Reputation.Value--;
 
-            var hasRemovedRep = _users.Senne.Reputation.MinusRepLog.TryAdd(_users.Peter.Id, DateTime.Now);
+            var hasRemovedRep = _users.Senne.Reputation.MinusRepLog.TryAdd(_users.Peter.UserId, DateTime.Now);
             _dateTimeMock.Setup(dt => dt.Now).Returns(DateTime.Now.AddSeconds(_repProvider.TimeoutInSeconds + 1));
             var peterHasTimeout = _repProvider.CanRemoveReputation(_users.Peter, _users.Senne);
             var senneHasTimeout = _repProvider.CanRemoveReputation(_users.Senne, _users.Peter);

--- a/src/Miunie.Core.XUnit.Tests/Services/ProfileServiceReputationTests.cs
+++ b/src/Miunie.Core.XUnit.Tests/Services/ProfileServiceReputationTests.cs
@@ -26,9 +26,9 @@ namespace Miunie.Core.XUnit.Tests.Services
             _profileService = new ProfileService(discordMsgMock.Object, _repProviderMock.Object, new Mock<ILogWriter>().Object);
             _users = new DummyMiunieUsers();
 
-            _hasDraxId = u => u.Id == _users.Drax.Id;
-            _hasPeterId = u => u.Id == _users.Peter.Id;
-            _hasSenneId = u => u.Id == _users.Senne.Id;
+            _hasDraxId = u => u.UserId == _users.Drax.UserId;
+            _hasPeterId = u => u.UserId == _users.Peter.UserId;
+            _hasSenneId = u => u.UserId == _users.Senne.UserId;
         }
 
         [Fact]

--- a/src/Miunie.Core/Entities/MiunieUser.cs
+++ b/src/Miunie.Core/Entities/MiunieUser.cs
@@ -6,9 +6,25 @@ namespace Miunie.Core
 {
     public class MiunieUser
     {
+        public Guid Id
+        {
+            get
+            {
+                return GenerateSeededGuid();
+            }
+        }
+
+        private Guid GenerateSeededGuid()
+        {
+            var left = BitConverter.GetBytes(GuildId);
+            var right = BitConverter.GetBytes(UserId);
+            var bytes = left.Concat(right).ToArray();
+            return new Guid(bytes);
+        }
+
         public string Name { get; set; }
         public ulong GuildId { get; set; }
-        public ulong Id { get; set; }
+        public ulong UserId { get; set; }
         public Reputation Reputation { get; set; }
         public List<ulong> NavCursor { get; set; }
         public DateTime JoinedAt { get; set; }
@@ -21,6 +37,8 @@ namespace Miunie.Core
         {
             NavCursor = new List<ulong>();
         }
+
+
     }
 }
 

--- a/src/Miunie.Core/Providers/MiunieUserProvider.cs
+++ b/src/Miunie.Core/Providers/MiunieUserProvider.cs
@@ -15,13 +15,13 @@ namespace Miunie.Core.Providers
 
         public MiunieUser GetById(ulong userId, ulong guildId)
         {
-            var user = _persistentStorage.RestoreSingle<MiunieUser>(u => u.Id == userId && u.GuildId == guildId);
+            var user = _persistentStorage.RestoreSingle<MiunieUser>(u => u.UserId == userId && u.GuildId == guildId);
             return EnsureExistence(user, userId, guildId);
         }
 
         public void StoreUser(MiunieUser user)
         {
-            if (_persistentStorage.Exists<MiunieUser>(u => u.Id == user.Id && u.GuildId == user.GuildId))
+            if (_persistentStorage.Exists<MiunieUser>(u => u.UserId == user.UserId && u.GuildId == user.GuildId))
             {
                 _persistentStorage.Update(user);
             }
@@ -41,7 +41,7 @@ namespace Miunie.Core.Providers
                 user = new MiunieUser
                 {
                     GuildId = guildId,
-                    Id = userId,
+                    UserId = userId,
                     Reputation = new Reputation()
                 };
                 StoreUser(user);

--- a/src/Miunie.Core/Providers/UserReputationProvider.cs
+++ b/src/Miunie.Core/Providers/UserReputationProvider.cs
@@ -20,14 +20,14 @@ namespace Miunie.Core.Providers
         public void AddReputation(MiunieUser invoker, MiunieUser target)
         {
             target.Reputation.Value++;
-            target.Reputation.PlusRepLog.TryAdd(invoker.Id, _dateTime.Now);
+            target.Reputation.PlusRepLog.TryAdd(invoker.UserId, _dateTime.Now);
             _userProvider.StoreUser(target);
         }
 
         public void RemoveReputation(MiunieUser invoker, MiunieUser target)
         {
             target.Reputation.Value--;
-            target.Reputation.MinusRepLog.TryAdd(invoker.Id, _dateTime.Now);
+            target.Reputation.MinusRepLog.TryAdd(invoker.UserId, _dateTime.Now);
             _userProvider.StoreUser(target);
         }
 
@@ -39,11 +39,11 @@ namespace Miunie.Core.Providers
 
         private bool HasTimeout(ConcurrentDictionary<ulong, DateTime> log, MiunieUser invoker)
         {
-            log.TryGetValue(invoker.Id, out var lastRepDateTime);
+            log.TryGetValue(invoker.UserId, out var lastRepDateTime);
 
             if ((_dateTime.Now - lastRepDateTime).TotalSeconds <= TimeoutInSeconds) { return true; }
 
-            log.TryRemove(invoker.Id, out _);
+            log.TryRemove(invoker.UserId, out _);
             _userProvider.StoreUser(invoker);
             return false;
         }

--- a/src/Miunie.Core/Services/ProfileService.cs
+++ b/src/Miunie.Core/Services/ProfileService.cs
@@ -22,7 +22,7 @@ namespace Miunie.Core
 
         public async Task GiveReputationAsync(MiunieUser invoker, MiunieUser target, MiunieChannel c)
         {
-            if (invoker.Id == target.Id)
+            if (invoker.UserId == target.UserId)
             {
                 await _discordMessages.SendMessageAsync(c, PhraseKey.CANNOT_SELF_REP, invoker.Name);
                 return;
@@ -40,7 +40,7 @@ namespace Miunie.Core
 
         public async Task RemoveReputationAsync(MiunieUser invoker, MiunieUser target, MiunieChannel c)
         {
-            if (invoker.Id == target.Id)
+            if (invoker.UserId == target.UserId)
             {
                 await _discordMessages.SendMessageAsync(c, PhraseKey.CANNOT_SELF_REP, invoker.Name);
                 return;


### PR DESCRIPTION
Fixes #177 

### ⚠️ Warning
_**Please could you ensure that you delete your Miunie.db (LiteDb database file) before testing this commit.
All users that use Miunie as of this update will be required to delete their DB file as the old one will be using a now outdated Id for the Db entities.**_

## Changes
* Rename the MiunieUser Id property to UserId
* Implement a new Guid Id property that is set via a private SeededGuid method.

## Expected Feedback
I would love if someone else could also check this locally. 
When testing, please:
* Ensure you try the Profile command as-well as rep commands.
* Ensure you do this with at-least two different guilds.
* Ensure the Miunie.Db has two entries (One for the first guild you tried it in & another for the second).
